### PR TITLE
Expanded dice notation

### DIFF
--- a/python_dice/src/python_dice_expression/dice_expression.py
+++ b/python_dice/src/python_dice_expression/dice_expression.py
@@ -25,10 +25,12 @@ class DiceExpression(i_dice_expression.IDiceExpression):
         self._string_form = string_form
 
     def _get_number_of_dice(self) -> int:
-        return int(self._string_form.split("d")[0])
+        string_num = self._string_form.split("d")[0]
+        return 1 if string_num == "" else int(string_num)
 
     def _get_number_of_sides(self) -> int:
-        return int(self._string_form.split("d")[1])
+        string_num = self._string_form.split("d")[1]
+        return 100 if string_num == "%" else int(string_num)
 
     def roll(self) -> int:
         return sum(

--- a/python_dice/src/python_dice_syntax/dice_syntax.py
+++ b/python_dice/src/python_dice_syntax/dice_syntax.py
@@ -3,7 +3,7 @@ import python_dice.interface.python_dice_syntax.i_dice_syntax as i_dice_statemen
 
 class DiceSyntax(i_dice_statement.IDiceSyntax):
     TOKEN_NAME = "DICE"
-    TOKEN_REGEX = r"\d+d\d+"
+    TOKEN_REGEX = r"\d*d(\d+|%)"
 
     @staticmethod
     def get_token_name() -> str:

--- a/python_dice/test/python_dice_expression/test_dice_expression.py
+++ b/python_dice/test/python_dice_expression/test_dice_expression.py
@@ -1,3 +1,6 @@
+import itertools
+from collections import Counter
+
 import unittest
 import unittest.mock as mock
 
@@ -9,6 +12,8 @@ import python_dice.src.python_dice_expression.dice_expression as dice_expression
 class TestDiceExpression(unittest.TestCase):
     def setUp(self):
         self._test_dice = dice_expression.DiceExpression("4d6")
+        self._test_dice_no_dice_amount = dice_expression.DiceExpression("d10")
+        self._test_percentile_die = dice_expression.DiceExpression("1d%")
         self._mock_parser_gen = mock.create_autospec(rply.ParserGenerator)
 
     def test_dice_add_production_function(self):
@@ -18,6 +23,7 @@ class TestDiceExpression(unittest.TestCase):
         )
 
     def test_dice_roll(self):
+        # Test regular dice syntax
         self._test_dice = dice_expression.DiceExpression("2d10")
         roll_set = set()
         for _ in range(1000):
@@ -26,40 +32,57 @@ class TestDiceExpression(unittest.TestCase):
         self.assertEqual(20, max(roll_set))
         self.assertEqual(2, min(roll_set))
 
+        # Test missing dice amount syntax (i.e. "d10")
+        roll_set = set()
+        for _ in range(1000):
+            roll_set.add(self._test_dice_no_dice_amount.roll())
+        self.assertEqual(10, len(roll_set))
+        self.assertEqual(10, max(roll_set))
+        self.assertEqual(1, min(roll_set))
+
+        # Test percentile die syntax (i.e. "1d%")
+        roll_set = set()
+        for _ in range(10000):
+            roll_set.add(self._test_percentile_die.roll())
+        self.assertEqual(100, len(roll_set))
+        self.assertEqual(100, max(roll_set))
+        self.assertEqual(1, min(roll_set))
+
     def test_dice_max(self):
         self.assertEqual(24, self._test_dice.max())
+        self.assertEqual(10, self._test_dice_no_dice_amount.max())
+        self.assertEqual(100, self._test_percentile_die.max())
 
     def test_dice_min(self):
         self.assertEqual(4, self._test_dice.min())
+        self.assertEqual(1, self._test_dice_no_dice_amount.min())
+        self.assertEqual(1, self._test_percentile_die.min())
 
     def test_dice_str(self):
         self.assertEqual("4d6", str(self._test_dice))
+        self.assertEqual("d10", str(self._test_dice_no_dice_amount))
+        self.assertEqual("1d%", str(self._test_percentile_die))
 
     def test_dice_get_probability_distribution(self):
         self._test_dice = dice_expression.DiceExpression("4d6")
+        possible_rolls = itertools.product(range(1, 7), repeat = 4)
+        results = [sum(t) for t in possible_rolls]
         self.assertEqual(
-            {
-                4: 1,
-                5: 4,
-                6: 10,
-                7: 20,
-                8: 35,
-                9: 56,
-                10: 80,
-                11: 104,
-                12: 125,
-                13: 140,
-                14: 146,
-                15: 140,
-                16: 125,
-                17: 104,
-                18: 80,
-                19: 56,
-                20: 35,
-                21: 20,
-                22: 10,
-                23: 4,
-                24: 1,
-            },
-            self._test_dice.get_probability_distribution().get_result_map(),
+            dict(Counter(results)),
+            self._test_dice.get_probability_distribution().get_result_map()
+        )
+
+        possible_rolls = itertools.product(range(1, 11), repeat = 1)
+        results = [sum(t) for t in possible_rolls]
+        self.assertEqual(
+            dict(Counter(results)),
+            self._test_dice_no_dice_amount.get_probability_distribution().get_result_map()
+        )
+
+        self._test_percentile_dice = dice_expression.DiceExpression("2d%")
+        possible_rolls = itertools.product(range(1, 101), repeat = 2)
+        results = [sum(t) for t in possible_rolls]
+        self.assertEqual(
+            dict(Counter(results)),
+            self._test_percentile_dice.get_probability_distribution().get_result_map()
         )

--- a/python_dice/test/python_dice_syntax/test_dice_syntax.py
+++ b/python_dice/test/python_dice_syntax/test_dice_syntax.py
@@ -9,10 +9,10 @@ class TestDiceSyntax(unittest.TestCase):
         self.assertEqual("DICE", dice_syntax.DiceSyntax.get_token_name())
 
     def test_dice_get_token_regex(self):
-        self.assertEqual(r"\d+d\d+", dice_syntax.DiceSyntax.get_token_regex())
+        self.assertEqual(r"\d*d(\d+|%)", dice_syntax.DiceSyntax.get_token_regex())
 
     def test_dice_regex_will_match(self):
-        test_cases = ["2d6", "10d4", "100d0", "1d90", "0d210321314", "12652125d12312"]
+        test_cases = ["2d6", "10d4", "100d0", "1d90", "0d210321314", "12652125d12312", "d6", "3d%", "d%"]
         for test_case in test_cases:
             self.assertTrue(
                 re.match(dice_syntax.DiceSyntax.get_token_regex(), test_case),
@@ -20,7 +20,7 @@ class TestDiceSyntax(unittest.TestCase):
             )
 
     def test_dice_regex_will_not_match(self):
-        test_cases = ["a", "just a string", "1da", "1", " ", "-", "*", "(", "ad21"]
+        test_cases = ["a", "just a string", "1da", "1", " ", "-", "*", "(", "ad21", "5d"]
         for test_case in test_cases:
             self.assertIsNone(
                 re.match(dice_syntax.DiceSyntax.get_token_regex(), test_case),

--- a/python_dice/test/test_python_dice_interpreter.py
+++ b/python_dice/test/test_python_dice_interpreter.py
@@ -12,7 +12,7 @@ class TestPythonDiceInterpreter(unittest.TestCase):
     def test_get_probability_distribution_dict(self):
         interpreter = python_dice_interpreter.PythonDiceInterpreter()
         program = [
-            "VAR save_roll = 1d20 + 8",
+            "VAR save_roll = d20 + 8",
             "VAR burning_arch_damage = 2d6",
             "VAR pass_save = ( save_roll >= 19 ) ",
             "VAR damage_half_on_save = burning_arch_damage // (pass_save + 1)",
@@ -40,7 +40,7 @@ class TestPythonDiceInterpreter(unittest.TestCase):
     def test_get_probability_distribution(self):
         interpreter = python_dice_interpreter.PythonDiceInterpreter()
         program = [
-            "VAR save_roll = 1d20 + 8",
+            "VAR save_roll = d20 + 8",
             "VAR burning_arch_damage = 2d6",
             "VAR pass_save = ( save_roll >= 19 ) ",
             "VAR damage_half_on_save = burning_arch_damage // (pass_save + 1)",
@@ -68,7 +68,7 @@ class TestPythonDiceInterpreter(unittest.TestCase):
     def test_roll_single_line(self):
         interpreter = python_dice_interpreter.PythonDiceInterpreter()
         program = [
-            "VAR save_roll = 1d20 + 8",
+            "VAR save_roll = d20 + 8",
             "VAR burning_arch_damage = 2d6",
             "VAR pass_save = ( save_roll >= 19 ) ",
             "VAR damage_half_on_save = burning_arch_damage // (pass_save + 1)",
@@ -81,7 +81,7 @@ class TestPythonDiceInterpreter(unittest.TestCase):
     def test_min_single_line(self):
         interpreter = python_dice_interpreter.PythonDiceInterpreter()
         program = [
-            "VAR save_roll = 1d20 + 8",
+            "VAR save_roll = d20 + 8",
             "VAR burning_arch_damage = 2d6",
             "VAR pass_save = ( save_roll >= 19 ) ",
             "VAR damage_half_on_save = burning_arch_damage // (pass_save + 1)",
@@ -91,7 +91,7 @@ class TestPythonDiceInterpreter(unittest.TestCase):
     def test_max_single_line(self):
         interpreter = python_dice_interpreter.PythonDiceInterpreter()
         program = [
-            "VAR save_roll = 1d20 + 8",
+            "VAR save_roll = d20 + 8",
             "VAR burning_arch_damage = 2d6",
             "VAR pass_save = ( save_roll >= 19 ) ",
             "burning_arch_damage // (pass_save + 1)",
@@ -101,7 +101,7 @@ class TestPythonDiceInterpreter(unittest.TestCase):
     def test_average(self):
         interpreter = python_dice_interpreter.PythonDiceInterpreter()
         program = [
-            "VAR save_roll = 1d20 + 8",
+            "VAR save_roll = d20 + 8",
             "VAR burning_arch_damage = 2d6",
             "VAR pass_save = ( save_roll >= 19 ) ",
             "VAR damage_half_on_save = burning_arch_damage // (pass_save + 1)",
@@ -111,7 +111,7 @@ class TestPythonDiceInterpreter(unittest.TestCase):
     def disabled_test_get_histogram(self):
         interpreter = python_dice_interpreter.PythonDiceInterpreter()
         program = [
-            "VAR save_roll = 1d20 + 8",
+            "VAR save_roll = d20 + 8",
             "VAR burning_arch_damage = 9d6 + 9",
             "VAR pass_save = ( save_roll >= 19 ) ",
             "VAR damage_half_on_save = burning_arch_damage // (pass_save + 1)",
@@ -130,7 +130,7 @@ class TestPythonDiceInterpreter(unittest.TestCase):
     def disabled_test_get_at_least_histogram(self):
         interpreter = python_dice_interpreter.PythonDiceInterpreter()
         program = [
-            "VAR save_roll = 1d20 + 8",
+            "VAR save_roll = d20 + 8",
             "VAR burning_arch_damage = 9d6 + 9",
             "VAR pass_save = ( save_roll >= 19 ) ",
             "VAR damage_half_on_save = burning_arch_damage // (pass_save + 1)",

--- a/python_dice/test/test_python_dice_lexer.py
+++ b/python_dice/test/test_python_dice_lexer.py
@@ -77,19 +77,19 @@ class TestPythonDiceLexer(unittest.TestCase):
         )
 
     def test_lex_dice(self):
-        tokens = self._test_lexer.lex("1d4 * 4d6 + 10d1 - -10000000")
+        tokens = self._test_lexer.lex("d4 * 4d6 + 10d1 + 2d% - -10000000")
 
         self.assertEqual(
-            ["DICE", "MULTIPLY", "DICE", "ADD", "DICE", "SUBTRACT", "CONSTANT_INTEGER"],
+            ["DICE", "MULTIPLY", "DICE", "ADD", "DICE", "ADD", "DICE", "SUBTRACT", "CONSTANT_INTEGER"],
             [token.name for token in tokens],
         )
         self.assertEqual(
-            ["1d4", "*", "4d6", "+", "10d1", "-", "-10000000"],
+            ["d4", "*", "4d6", "+", "10d1", "+", "2d%", "-", "-10000000"],
             [token.value for token in tokens],
         )
 
     def test_lex_parenthesis(self):
-        tokens = self._test_lexer.lex("((1d4 * 4d6) + 10d1) - -10000000")
+        tokens = self._test_lexer.lex("((d4 * 4d6) + 10d1 + 2d%) - -10000000")
 
         self.assertEqual(
             [
@@ -99,6 +99,8 @@ class TestPythonDiceLexer(unittest.TestCase):
                 "MULTIPLY",
                 "DICE",
                 "CLOSE_PARENTHESIS",
+                "ADD",
+                "DICE",
                 "ADD",
                 "DICE",
                 "CLOSE_PARENTHESIS",
@@ -108,12 +110,12 @@ class TestPythonDiceLexer(unittest.TestCase):
             [token.name for token in tokens],
         )
         self.assertEqual(
-            ["(", "(", "1d4", "*", "4d6", ")", "+", "10d1", ")", "-", "-10000000"],
+            ["(", "(", "d4", "*", "4d6", ")", "+", "10d1", "+", "2d%", ")", "-", "-10000000"],
             [token.value for token in tokens],
         )
 
     def test_lex_constant_binary(self):
-        tokens = self._test_lexer.lex("((1d4 * True) + 10d1) - False")
+        tokens = self._test_lexer.lex("((d4 * True) + 10d1 + 2d%) - False")
 
         self.assertEqual(
             [
@@ -125,6 +127,8 @@ class TestPythonDiceLexer(unittest.TestCase):
                 "CLOSE_PARENTHESIS",
                 "ADD",
                 "DICE",
+                "ADD",
+                "DICE",
                 "CLOSE_PARENTHESIS",
                 "SUBTRACT",
                 "CONSTANT_BINARY",
@@ -132,12 +136,12 @@ class TestPythonDiceLexer(unittest.TestCase):
             [token.name for token in tokens],
         )
         self.assertEqual(
-            ["(", "(", "1d4", "*", "True", ")", "+", "10d1", ")", "-", "False"],
+            ["(", "(", "d4", "*", "True", ")", "+", "10d1", "+", "2d%", ")", "-", "False"],
             [token.value for token in tokens],
         )
 
     def test_lex_not(self):
-        tokens = self._test_lexer.lex("!(!1d4 + True)")
+        tokens = self._test_lexer.lex("!(!d4 + True)")
 
         self.assertEqual(
             [
@@ -152,69 +156,69 @@ class TestPythonDiceLexer(unittest.TestCase):
             [token.name for token in tokens],
         )
         self.assertEqual(
-            ["!", "(", "!", "1d4", "+", "True", ")"], [token.value for token in tokens]
+            ["!", "(", "!", "d4", "+", "True", ")"], [token.value for token in tokens]
         )
 
     def test_lex_equals(self):
-        tokens = self._test_lexer.lex("1d4 == True")
+        tokens = self._test_lexer.lex("d4 == True")
 
         self.assertEqual(
             ["DICE", "BINARY_OPERATOR", "CONSTANT_BINARY"],
             [token.name for token in tokens],
         )
-        self.assertEqual(["1d4", "==", "True"], [token.value for token in tokens])
+        self.assertEqual(["d4", "==", "True"], [token.value for token in tokens])
 
     def test_lex_not_equals(self):
-        tokens = self._test_lexer.lex("1d4 != True")
+        tokens = self._test_lexer.lex("d4 != True")
 
         self.assertEqual(
             ["DICE", "BINARY_OPERATOR", "CONSTANT_BINARY"],
             [token.name for token in tokens],
         )
-        self.assertEqual(["1d4", "!=", "True"], [token.value for token in tokens])
+        self.assertEqual(["d4", "!=", "True"], [token.value for token in tokens])
 
     def test_lex_less_than(self):
-        tokens = self._test_lexer.lex("1d4 < True <= 1d3")
+        tokens = self._test_lexer.lex("d4 < True <= 1d3")
 
         self.assertEqual(
             ["DICE", "BINARY_OPERATOR", "CONSTANT_BINARY", "BINARY_OPERATOR", "DICE"],
             [token.name for token in tokens],
         )
         self.assertEqual(
-            ["1d4", "<", "True", "<=", "1d3"], [token.value for token in tokens]
+            ["d4", "<", "True", "<=", "1d3"], [token.value for token in tokens]
         )
 
     def test_lex_greater_than(self):
-        tokens = self._test_lexer.lex("1d4 > True >= 1d3")
+        tokens = self._test_lexer.lex("d4 > True >= 1d3")
 
         self.assertEqual(
             ["DICE", "BINARY_OPERATOR", "CONSTANT_BINARY", "BINARY_OPERATOR", "DICE"],
             [token.name for token in tokens],
         )
         self.assertEqual(
-            ["1d4", ">", "True", ">=", "1d3"], [token.value for token in tokens]
+            ["d4", ">", "True", ">=", "1d3"], [token.value for token in tokens]
         )
 
     def test_lex_and(self):
-        tokens = self._test_lexer.lex("1d4 AND True")
+        tokens = self._test_lexer.lex("d4 AND True")
 
         self.assertEqual(
             ["DICE", "BINARY_OPERATOR", "CONSTANT_BINARY"],
             [token.name for token in tokens],
         )
-        self.assertEqual(["1d4", "AND", "True"], [token.value for token in tokens])
+        self.assertEqual(["d4", "AND", "True"], [token.value for token in tokens])
 
     def test_lex_or(self):
-        tokens = self._test_lexer.lex("1d4 OR True")
+        tokens = self._test_lexer.lex("d4 OR True")
 
         self.assertEqual(
             ["DICE", "BINARY_OPERATOR", "CONSTANT_BINARY"],
             [token.name for token in tokens],
         )
-        self.assertEqual(["1d4", "OR", "True"], [token.value for token in tokens])
+        self.assertEqual(["d4", "OR", "True"], [token.value for token in tokens])
 
     def test_lex_max(self):
-        tokens = self._test_lexer.lex("MAX(1d4, 3)")
+        tokens = self._test_lexer.lex("MAX(d4, 3)")
 
         self.assertEqual(
             [
@@ -228,7 +232,7 @@ class TestPythonDiceLexer(unittest.TestCase):
             [token.name for token in tokens],
         )
         self.assertEqual(
-            ["MAX", "(", "1d4", ",", "3", ")"], [token.value for token in tokens]
+            ["MAX", "(", "d4", ",", "3", ")"], [token.value for token in tokens]
         )
 
     def test_lex_min(self):
@@ -259,11 +263,11 @@ class TestPythonDiceLexer(unittest.TestCase):
         self.assertEqual(["ABS", "(", "1d6", ")"], [token.value for token in tokens])
 
     def test_lex_var(self):
-        tokens = self._test_lexer.lex("VAR apple = 1d4")
+        tokens = self._test_lexer.lex("VAR apple = d4")
 
         self.assertEqual(
             ["VAR", "NAME", "ASSIGNMENT", "DICE"], [token.name for token in tokens]
         )
         self.assertEqual(
-            ["VAR", "apple", "=", "1d4"], [token.value for token in tokens]
+            ["VAR", "apple", "=", "d4"], [token.value for token in tokens]
         )

--- a/python_dice/test/test_python_dice_parser.py
+++ b/python_dice/test/test_python_dice_parser.py
@@ -28,7 +28,7 @@ class TestPythonDiceParser(unittest.TestCase):
         )
 
     def test_parser_error(self):
-        for invalid in ["2d30 1", "(((1d2) + 1 ) + 1 ) + 1)"]:
+        for invalid in ["2d30 1", "(((d2) + 1 ) + 1 ) + 1)"]:
             self.assertRaises(ValueError, self._test_parser.parse, invalid)
 
     def test_parser_constant_integer(self):
@@ -82,17 +82,17 @@ class TestPythonDiceParser(unittest.TestCase):
         self.assert_distribution(token, expected_outcome, 1, 5)
 
     def test_parser_dice_add(self):
-        token, _ = self._test_parser.parse("2d4 + 1d2")
+        token, _ = self._test_parser.parse("2d4 + d2")
         expected_outcome = {3: 1, 4: 3, 5: 5, 6: 7, 7: 7, 8: 5, 9: 3, 10: 1}
         self.assert_distribution(token, expected_outcome, 3, 10)
 
     def test_parser_dice_subtract(self):
-        token, _ = self._test_parser.parse("2d4 - 1d2")
+        token, _ = self._test_parser.parse("2d4 - d2")
         expected_outcome = {0: 1, 1: 3, 2: 5, 3: 7, 4: 7, 5: 5, 6: 3, 7: 1}
         self.assert_distribution(token, expected_outcome, 0, 7)
 
     def test_parser_dice_multiply(self):
-        token, _ = self._test_parser.parse("2d4 * 1d2")
+        token, _ = self._test_parser.parse("2d4 * d2")
         expected_outcome = {
             2: 1,
             4: 4,
@@ -109,12 +109,12 @@ class TestPythonDiceParser(unittest.TestCase):
         self.assert_distribution(token, expected_outcome, 2, 16)
 
     def test_parser_dice_division(self):
-        token, _ = self._test_parser.parse("2d4 // 1d2")
+        token, _ = self._test_parser.parse("2d4 // d2")
         expected_outcome = {2: 8, 1: 3, 3: 7, 4: 4, 5: 4, 6: 3, 7: 2, 8: 1}
         self.assert_distribution(token, expected_outcome, 1, 8)
 
     def test_parser_dice_full_test(self):
-        token, _ = self._test_parser.parse("2d4 * 1d2 + 6d6 // 1d4")
+        token, _ = self._test_parser.parse("2d4 * d2 + 6d6 // 1d4")
         expected_outcome = {
             8: 150534,
             5: 5474,


### PR DESCRIPTION
Expands the dice syntax to contain two standard notations in roleplaying dice:

1. The number of dice can now be omitted, and will be treated as 1 in this case.

2. "%" can now be used as the number of dice sides, and will be treated as 100.

This is quite usual syntax in many roleplaying systems. This allows writing just "d6" for example, or "d%" for a percentile roll.