### PR TITLE
Corrected var expression estimated cost

### DIFF
--- a/python_dice/src/python_dice_expression/var_assignment_expression.py
+++ b/python_dice/src/python_dice_expression/var_assignment_expression.py
@@ -56,7 +56,7 @@ class VarAssignmentExpression(i_dice_expression.IDiceExpression):
     def estimated_cost(self) -> int:
         cost = self._expression.estimated_cost()
         self._state.set_constant(self._name, cost)
-        return 2
+        return 2 + cost
 
     def get_probability_distribution(
         self,


### PR DESCRIPTION
The cost for the expression to be assigned was being calculated already, but the overall cost of the var expression was set to be 2, so I left the 2 to represent the cost of assigning the a value to a variable and I added the already calculated expression cost.